### PR TITLE
Add Laravel 11 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "email": "cyrill.kalita@gmail.com"
     }],
     "require": {
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "illuminate/validation": "^8.0|^9.0|^10.0",
-        "nesbot/carbon": "^2.0"
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0",
+        "illuminate/validation": "^8.0|^9.0|^10.0|^11.0",
+        "nesbot/carbon": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
+<phpunit
+    backupGlobals="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    backupStaticProperties="false"
 >
     <testsuites>
         <testsuite name="Sanitizer Test Suite">


### PR DESCRIPTION
Hey there, made a small change for Laravel 11 compatibility.
Laravel 11 also bumped carbon to 3.0, so I modified that as well.
PHPUnit 10 deprecated a few arguments in the phpunit.xml file, I removed them.